### PR TITLE
fix: グリッドのオブジェクト上に正しく配置されるように修正

### DIFF
--- a/Assets/Programmer/Prefabs/Room1.prefab
+++ b/Assets/Programmer/Prefabs/Room1.prefab
@@ -3026,7 +3026,7 @@ GameObject:
   - component: {fileID: 1075178380076985343}
   m_Layer: 0
   m_Name: Floors
-  m_TagString: Untagged
+  m_TagString: Floor
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -3071,6 +3071,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   gridDivision: {x: 11, y: 9}
+  layer:
+    serializedVersion: 2
+    m_Bits: 2147483648
 --- !u!65 &1075178380076985343
 BoxCollider:
   m_ObjectHideFlags: 0

--- a/Assets/Programmer/Prefabs/Room2.prefab
+++ b/Assets/Programmer/Prefabs/Room2.prefab
@@ -2008,7 +2008,7 @@ GameObject:
   - component: {fileID: 1097656220713533566}
   m_Layer: 0
   m_Name: Floors
-  m_TagString: Untagged
+  m_TagString: Floor
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -2054,6 +2054,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   gridDivision: {x: 9, y: 12}
+  layer:
+    serializedVersion: 2
+    m_Bits: 0
 --- !u!65 &1097656220713533566
 BoxCollider:
   m_ObjectHideFlags: 0

--- a/Assets/Programmer/Prefabs/Room3.prefab
+++ b/Assets/Programmer/Prefabs/Room3.prefab
@@ -3109,7 +3109,7 @@ GameObject:
   - component: {fileID: 4057566066426908618}
   m_Layer: 0
   m_Name: Floors
-  m_TagString: Untagged
+  m_TagString: Floor
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Programmer/Prefabs/Room4.prefab
+++ b/Assets/Programmer/Prefabs/Room4.prefab
@@ -4104,7 +4104,7 @@ GameObject:
   - component: {fileID: 2386547234261193162}
   m_Layer: 0
   m_Name: Floors
-  m_TagString: Untagged
+  m_TagString: Floor
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Programmer/Scripts/Player/PlayerAction.cs
+++ b/Assets/Programmer/Scripts/Player/PlayerAction.cs
@@ -19,6 +19,7 @@ public class PlayerAction : MonoBehaviour
     public List<GameObject> gimmickKind;//所持しているギミックの種類
     
     private PlayerData playerData;
+    private GameObject currentRoom;
     GameObject interactObject = null;
 
     // Start is called before the first frame update
@@ -103,30 +104,28 @@ public class PlayerAction : MonoBehaviour
         {
             Debug.LogError("選択されたギミックにGimmickBaseコンポーネントが付いていません"); return;
         }
-        if (currentSoul - gimmick.requiredSoul <= 0) return;    // ソウルが足りない場合召喚しない
+        if (currentSoul - gimmick.requiredSoul < 0)
+        {
+            Debug.Log("ソウルが不足しています");
+            return;    // ソウルが足りない場合召喚しない
+        }
+        if (currentRoom == null)
+        {
+            Debug.Log("この部屋にトラップは配置できません");
+            return;    // 設置可能な部屋のみ設置する
+        }
 
-        var roomGrid = playerData.currentRoomData.GetPlayerRoomData().transform.GetChild(0).Find("Floors").Find("Plane").GetComponent<RoomGrid>();
+        var roomGrid = currentRoom.GetComponent<RoomGrid>();
 
         //ギミックの生成位置
         Vector3 settingPos = Vector3.zero;
-        settingPos = transform.position +
-            new Vector3(
-                transform.forward.x * roomGrid.gridSize.x,
-                0.0f,
-                transform.forward.z * roomGrid.gridSize.y);
+        settingPos = transform.position;
 
         //グリッドの位置に召喚を試みる
         if (!roomGrid.SetGimmickInGrid(settingPos, gimmick)) return;    // 召喚に失敗
 
         //ソウルの消費
         currentSoul -= gimmick.requiredSoul;
-
-        // ソウルが0未満になる場合は召喚を行わずソウル数を戻す
-        if (currentSoul < 0)
-        {
-            currentSoul += gimmick.requiredSoul;
-            Destroy(gimmick.gameObject);
-        }
     }
 
     //ソウルの数を加算する関数
@@ -147,7 +146,15 @@ public class PlayerAction : MonoBehaviour
         }
     }
 
-    private void OnCollisionExit(Collision collision)
+    private void OnTriggerEnter(Collider collision)
+    {
+        if (collision.gameObject.CompareTag("Floor"))
+        {
+            currentRoom = collision.gameObject;
+        }
+    }
+
+    private void OnTriggerExit(Collider collision)
     {
         if (collision.gameObject.CompareTag("Gimmick"))
         {

--- a/Assets/Programmer/Scripts/Room/RoomGrid.cs
+++ b/Assets/Programmer/Scripts/Room/RoomGrid.cs
@@ -6,6 +6,7 @@
  * 2026-04-21 | 初回作成
  * 
  */
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -67,7 +68,24 @@ public class RoomGrid : MonoBehaviour
 
         Vector3 spawnPos = GetWorldPosFromGrid(grid);
         if (spawnPos == Vector3.positiveInfinity) return false;
+        Ray ray = new Ray();
+        ray.direction = Vector3.down;
+        const float rayOriginY = 255f;
+        ray.origin = new Vector3(spawnPos.x, rayOriginY, spawnPos.z);
+        RaycastHit[] hits = Physics.RaycastAll(ray, Mathf.Abs(rayOriginY - gameObject.transform.position.y));
+        Array.Sort(hits, (a, b) => a.distance.CompareTo(b.distance));
+        GameObject hitObject = null;
+        foreach(var hitItem in hits)
+        {
+            Debug.Log(hitItem.transform.gameObject.name);
+            if (hitItem.transform.CompareTag("Player")) continue;
+            if (hitItem.transform.CompareTag("Thief")) continue;
 
+            hitObject = hitItem.transform.gameObject;
+            break;
+        }
+
+        if (hitObject != null && hitObject != gameObject) spawnPos.y = hitObject.transform.position.y + hitObject.transform.lossyScale.y / 2.0f;
         GameObject gimmickObject = Instantiate(gimmick.gameObject, spawnPos, Quaternion.identity);
         GimmickBase spawnGimmick = gimmickObject.GetComponent<GimmickBase>();
         spawnGimmick.roomGrid = this;

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -7,6 +7,8 @@ TagManager:
   - Gimmick
   - RoomCreatePoint
   - RoomMovePoint
+  - Floor
+  - Plane
   layers:
   - Default
   - TransparentFX
@@ -36,7 +38,7 @@ TagManager:
   - 
   - 
   - 
-  - 
+  - Player
   - Thief
   - VisionTarget
   - VisionObstacle


### PR DESCRIPTION
現在部屋の取り方を修正、最適化の過程でどちらかに統一します。
RoomのFloorに識別用tagを追加。