### PR TITLE
fix: 大岩の当たった判定が取れてないのを修正

### DIFF
--- a/Assets/Programmer/Prefabs/Gimmick/Rock.prefab
+++ b/Assets/Programmer/Prefabs/Gimmick/Rock.prefab
@@ -136,7 +136,7 @@ MonoBehaviour:
   hitCheckerPrefab: {fileID: 5250139902968933795, guid: 20e32c23a30b34c45916d0dcbd7a0e58,
     type: 3}
   gimmickDirection: 0
-  gimmickType: 0
+  gimmickType: 1
   gimmick: 2
   gimmickState: 0
   Adjust: 1

--- a/Assets/Programmer/Scripts/Gimmick/Base/HitChecker.cs
+++ b/Assets/Programmer/Scripts/Gimmick/Base/HitChecker.cs
@@ -151,6 +151,11 @@ public class HitChecker : MonoBehaviour
                         {
                             case Gimmick.Pot:
                                 EnemyDame(effectEnemies[i].gameObject, effectDamage);
+                                Debug.Log("EffectDamage_Pot");
+                                break;
+                            case Gimmick.IronBall:
+                                EnemyDame(effectEnemies[i].gameObject, effectDamage);
+                                Debug.Log("EffectDamage_IronBall");
                                 break;
                             case Gimmick.EmptyChest:
                                 EnemyCharm(effectEnemies[i].gameObject);
@@ -172,6 +177,11 @@ public class HitChecker : MonoBehaviour
                     {
                         case Gimmick.Pot:
                             EnemyDame(enemy, hitDamage);
+                            Debug.Log("HitDamage_Pot");
+                            break;
+                        case Gimmick.IronBall:
+                            EnemyDame(enemy, hitDamage);
+                            Debug.Log("HitDamage_IronBall");
                             break;
                         case Gimmick.EmptyChest:
                             EnemyCharm(enemy);

--- a/Assets/Programmer/Scripts/Gimmick/RockGimmick.cs
+++ b/Assets/Programmer/Scripts/Gimmick/RockGimmick.cs
@@ -128,7 +128,7 @@ public class RockGimmick : GimmickBase
             Vector3 rayXYOrigin = new Vector3(transform.position.x, transform.position.y - 1.3f, transform.position.z);
             // レイデバッグ
             Debug.DrawRay(rayXYOrigin, velocity * raySideLength, Color.yellow);
-            Debug.Log(rayXYOrigin);
+            //Debug.Log(rayXYOrigin);
             //レイ判定
             if (Physics.Raycast(rayXYOrigin, velocity, out check, raySideLength))
             {//レイが当たったら角度をチェック


### PR DESCRIPTION
現在のバグとして
当たり判定のLoopによって
毎フレーム当たり続け、ソウルが増え続けるバグと
地面判定をとるために用意した
下方へのレイが泥棒にも当たってしまうため
それにより上方へ位置ズレが発生するバグがあります。
※これらは金曜AT授業までを最終期限と設定して対応します。