### PR TITLE
fix: 大岩の重複当たりの修正

### DIFF
--- a/Assets/Programmer/Prefabs/Gimmick/Rock.prefab
+++ b/Assets/Programmer/Prefabs/Gimmick/Rock.prefab
@@ -135,10 +135,10 @@ MonoBehaviour:
   roomGrid: {fileID: 0}
   hitCheckerPrefab: {fileID: 5250139902968933795, guid: 20e32c23a30b34c45916d0dcbd7a0e58,
     type: 3}
-  gimmickDirection: 0
+  gimmickDirection: 1
   gimmickType: 1
   gimmick: 2
-  gimmickState: 0
+  gimmickState: 1
   Adjust: 1
   InteractUI: {fileID: 1696712630574914250, guid: daeb11669dd903946a24d89b6bedd87b,
     type: 3}

--- a/Assets/Programmer/Scripts/Gimmick/Base/HitChecker.cs
+++ b/Assets/Programmer/Scripts/Gimmick/Base/HitChecker.cs
@@ -24,6 +24,9 @@ public class HitChecker : MonoBehaviour
     private Gimmick gimmick;
     GameObject parentGameObject;
 
+    // 既にダメージを与えた敵を保存
+    private HashSet<GameObject> damagedEnemies = new HashSet<GameObject>();
+
     /// <summary>
     /// 当たり判定の処理をループさせるかどうか
     /// </summary>
@@ -111,10 +114,22 @@ public class HitChecker : MonoBehaviour
     /// <param name="damage"></param>
     private void EnemyDame(GameObject enemy, int damage)
     {
+        // =====================================================
+        // 一度ダメージを与えた敵には再度当てない
+        // =====================================================
+        if (damagedEnemies.Contains(enemy))
+        {
+            return;
+        }
+
         ThiefAI thiefAI = enemy.GetComponent<ThiefAI>();
+
         if (thiefAI != null)
         {
-            thiefAI.TakeDamage(effectDamage, gimmick);
+            thiefAI.TakeDamage(damage, gimmick);
+
+            // ダメージ済み登録
+            damagedEnemies.Add(enemy);
         }
     }
 
@@ -132,63 +147,83 @@ public class HitChecker : MonoBehaviour
     }
     private void FixedUpdate()
     {
-        if(firstUpdate || isLoop)
+        if (firstUpdate || isLoop)
         {
             firstUpdate = false;
 
-            Collider[] hitEnemies = GetHitEnemies();
-            Collider[] effectEnemies = GetEffectEnemies();
+            Collider[] hitEnemies =
+                GetHitEnemies();
 
+            Collider[] effectEnemies =
+                GetEffectEnemies();
 
-            for(int i = 0; i < effectEnemies.Length; i++)
+            // =====================================================
+            // 効果範囲
+            // =====================================================
+            for (int i = 0 ; i < effectEnemies.Length ; i++)
             {
-                for(int j = 0; j < hitEnemies.Length; j++)
+                bool isHitEnemy = false;
+
+                // hitEnemies に含まれているか確認
+                for (int j = 0 ; j < hitEnemies.Length ; j++)
                 {
-                    // 効果範囲内のみの敵に対する処理
-                    if (effectEnemies[i] != hitEnemies[j])
+                    if (effectEnemies[i] == hitEnemies[j])
                     {
-                        switch(gimmick)
-                        {
-                            case Gimmick.Pot:
-                                EnemyDame(effectEnemies[i].gameObject, effectDamage);
-                                Debug.Log("EffectDamage_Pot");
-                                break;
-                            case Gimmick.IronBall:
-                                EnemyDame(effectEnemies[i].gameObject, effectDamage);
-                                Debug.Log("EffectDamage_IronBall");
-                                break;
-                            case Gimmick.EmptyChest:
-                                EnemyCharm(effectEnemies[i].gameObject);
-                                Debug.Log("EffectCharm");
-                                break;
-                        }
+                        isHitEnemy = true;
+                        break;
+                    }
+                }
+
+                // hit範囲にいない敵のみ
+                if (!isHitEnemy)
+                {
+                    GameObject enemy =
+                        effectEnemies[i].gameObject;
+
+                    switch (gimmick)
+                    {
+                        case Gimmick.Pot:
+                            EnemyDame(enemy, effectDamage);
+                            break;
+                        case Gimmick.IronBall:
+                            EnemyDame(enemy, effectDamage);
+                            break;
+                        case Gimmick.EmptyChest:
+                            EnemyCharm(enemy);
+                            break;
                     }
                 }
             }
 
-            // 命中範囲内の敵に対する処理
+            // =====================================================
+            // 命中範囲
+            // =====================================================
             for (int i = 0 ; i < hitEnemies.Length ; i++)
             {
-                GameObject enemy = hitEnemies[i].gameObject;
-                ThiefAI thiefAI = enemy.GetComponent<ThiefAI>();
+                GameObject enemy =
+                    hitEnemies[i].gameObject;
+
+                ThiefAI thiefAI =
+                    enemy.GetComponent<ThiefAI>();
+
                 if (thiefAI != null)
                 {
-                    switch(gimmick)
+                    switch (gimmick)
                     {
                         case Gimmick.Pot:
                             EnemyDame(enemy, hitDamage);
-                            Debug.Log("HitDamage_Pot");
                             break;
                         case Gimmick.IronBall:
                             EnemyDame(enemy, hitDamage);
-                            Debug.Log("HitDamage_IronBall");
                             break;
                         case Gimmick.EmptyChest:
                             EnemyCharm(enemy);
-                            EmptyChestGimmick emptyChestGimmick = parentGameObject.GetComponent<EmptyChestGimmick>();
-                            if(emptyChestGimmick != null)
+                            EmptyChestGimmick emptyChestGimmick =
+                                parentGameObject.GetComponent<EmptyChestGimmick>();
+                            if (emptyChestGimmick != null)
                             {
                                 emptyChestGimmick.Durability_Value_Decreased();
+
                                 Debug.Log("Durability decreased");
                             }
                             break;

--- a/Assets/Programmer/Scripts/Gimmick/RockGimmick.cs
+++ b/Assets/Programmer/Scripts/Gimmick/RockGimmick.cs
@@ -71,8 +71,11 @@ public class RockGimmick : GimmickBase
             isFirstActive = false;
             Vector2Int directionVec = GetDirectionVec();
 
-            initPositionY = transform.position.y;
+            initPositionY = transform.position.y + debugIdleOffset;
             velocity = Vector3.zero;
+
+            CS_PlayerAction playerAction = GameObject.FindObjectOfType<CS_PlayerAction>();
+            playerAction.SettingGimmickDirection(this);
         }
 
         // =========================
@@ -126,10 +129,12 @@ public class RockGimmick : GimmickBase
             {//X+
                 velocity = Vector3.left * rollSpeed;
             }
-            transform.position += velocity * Time.deltaTime;
-            //！！デバッグ用応急処置！！//
-            transform.position = new Vector3(transform.position.x, transform.position.y + debugIdleOffset, transform.position.z);
-
+            if (hit.collider.CompareTag("Plane") || hit.collider.CompareTag("Untagged"))
+            {
+                transform.position += velocity * Time.deltaTime;
+                //！！デバッグ用応急処置！！//
+                transform.position = new Vector3(transform.position.x, transform.position.y + debugIdleOffset, transform.position.z);
+            }
             //---------------
             // 壁判定
             // XZ方向にレイを飛ばす
@@ -143,7 +148,10 @@ public class RockGimmick : GimmickBase
             {//レイが当たったら角度をチェック
                 if (HitBrokeAngle(check, velocity, slopeAngleLimit))
                 {//当たった面が一定値以上の斜面なら
-                    gimmickState = GimmickState.Broken;
+                    if (hit.collider.CompareTag("Plane") || hit.collider.CompareTag("Untagged"))
+                    {
+                        gimmickState = GimmickState.Broken;
+                    }
                 }
             }
         }

--- a/Assets/Programmer/Scripts/Player/CS_PlayerAction.cs
+++ b/Assets/Programmer/Scripts/Player/CS_PlayerAction.cs
@@ -159,44 +159,6 @@ public class CS_PlayerAction : MonoBehaviour
                     if (gimmick == null) continue;
                     if (gimmick.gimmickState != GimmickState.Idle) continue;
 
-                    // インタラクト方向を設定※ギミックとの位置関係で判定（対角線で四分割：三角形×4）
-                    Vector3 gimmickPos = gimmick.transform.position;
-                    Vector3 toPlayer = transform.position - gimmickPos;
-                    float dx = toPlayer.x;
-                    float dz = toPlayer.z;
-
-                    // 三角形境界は z = ±x なので絶対値で比較する
-                    float adx = Mathf.Abs(dx);
-                    float adz = Mathf.Abs(dz);
-                    const float eps = 1e-5f; // 同値判定の小さな余裕
-
-                    if (dz > adx + eps)
-                    {
-                        // プレイヤーがギミックの「前（+Z）側の三角形」：Up
-                        gimmick.SetGimmickDirection(GimmickDirection.Up);
-                    }
-                    else if (-dz > adx + eps)
-                    {
-                        // プレイヤーがギミックの「後（-Z）側の三角形」：Down
-                        gimmick.SetGimmickDirection(GimmickDirection.Down);
-                    }
-                    else if (dx > adz + eps)
-                    {
-                        // プレイヤーがギミックの「右（+X）側の三角形」：Right
-                        gimmick.SetGimmickDirection(GimmickDirection.Right);
-                    }
-                    else if (-dx > adz + eps)
-                    {
-                        // プレイヤーがギミックの「左（-X）側の三角形」：Left
-                        gimmick.SetGimmickDirection(GimmickDirection.Left);
-                    }
-                    else
-                    {
-                        // 厳密な境界上（対角線上）に居る場合のフォールバック：
-                        // X/Z の絶対値で優勢側を使う（斜め真正面は Z 優先）
-                        if (adz >= adx) gimmick.SetGimmickDirection(dz >= 0f ? GimmickDirection.Up : GimmickDirection.Down);
-                        else gimmick.SetGimmickDirection(dx >= 0f ? GimmickDirection.Right : GimmickDirection.Left);
-                    }
                     //ギミックをアクティブにする
                     Debug.Log($"ギミック：" + hit.name + "がアクティブになりました");
                     gimmick.ActivateGimmick();
@@ -253,6 +215,52 @@ public class CS_PlayerAction : MonoBehaviour
 
         //ソウルの消費
         currentSoul -= gimmick.requiredSoul;
+    }
+
+    public void SettingGimmickDirection(GimmickBase gimmick)
+    {
+        // インタラクト方向を設定※ギミックとの位置関係で判定（対角線で四分割：三角形×4）
+        Vector3 gimmickPos = CalculateGimmickSetPosition();
+        Vector3 toPlayer = transform.position - gimmickPos;
+        float dx = toPlayer.x;
+        float dz = toPlayer.z;
+
+        // 三角形境界は z = ±x なので絶対値で比較する
+        float adx = Mathf.Abs(dx);
+        float adz = Mathf.Abs(dz);
+        const float eps = 1e-5f; // 同値判定の小さな余裕
+
+        if (dz > adx + eps)
+        {
+            // プレイヤーがギミックの「前（+Z）側の三角形」：Up
+            gimmick.SetGimmickDirection(GimmickDirection.Up);
+            Debug.Log("Up");
+        }
+        else if (-dz > adx + eps)
+        {
+            // プレイヤーがギミックの「後（-Z）側の三角形」：Down
+            gimmick.SetGimmickDirection(GimmickDirection.Down);
+            Debug.Log("Down");
+        }
+        else if (dx > adz + eps)
+        {
+            // プレイヤーがギミックの「右（+X）側の三角形」：Right
+            gimmick.SetGimmickDirection(GimmickDirection.Right);
+            Debug.Log("Right");
+        }
+        else if (-dx > adz + eps)
+        {
+            // プレイヤーがギミックの「左（-X）側の三角形」：Left
+            gimmick.SetGimmickDirection(GimmickDirection.Left);
+            Debug.Log("Left");
+        }
+        else
+        {
+            // 厳密な境界上（対角線上）に居る場合のフォールバック：
+            // X/Z の絶対値で優勢側を使う（斜め真正面は Z 優先）
+            if (adz >= adx) gimmick.SetGimmickDirection(dz >= 0f ? GimmickDirection.Up : GimmickDirection.Down);
+            else gimmick.SetGimmickDirection(dx >= 0f ? GimmickDirection.Right : GimmickDirection.Left);
+        }
     }
 
     //ギミックの設置位置を補正する計算：大瀧


### PR DESCRIPTION
大岩やその他のギミックにおける重複当たりが起こらないように修正しました。
※今現在当たり判定をループさせるのは大岩のみ
大岩がプレイヤーの上に乗るバグは直しましたが
新しく転がり時にカクつくというバグが出てきました