### PR TITLE
fix: GImmickTextImageの表示

### DIFF
--- a/Assets/Designer/UI/InGame/Number.png.meta
+++ b/Assets/Designer/UI/InGame/Number.png.meta
@@ -6,7 +6,7 @@ TextureImporter:
   serializedVersion: 13
   mipmaps:
     mipMapMode: 0
-    enableMipMap: 1
+    enableMipMap: 0
     sRGBTexture: 1
     linearTexture: 0
     fadeOut: 0
@@ -37,13 +37,13 @@ TextureImporter:
     filterMode: 1
     aniso: 1
     mipBias: 0
-    wrapU: 0
-    wrapV: 0
+    wrapU: 1
+    wrapV: 1
     wrapW: 0
-  nPOTScale: 1
+  nPOTScale: 0
   lightmap: 0
   compressionQuality: 50
-  spriteMode: 0
+  spriteMode: 1
   spriteExtrude: 1
   spriteMeshType: 1
   alignment: 0
@@ -52,9 +52,9 @@ TextureImporter:
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
-  alphaIsTransparency: 0
+  alphaIsTransparency: 1
   spriteTessellationDetail: -1
-  textureType: 0
+  textureType: 8
   textureShape: 1
   singleChannelComponent: 0
   flipbookRows: 1
@@ -99,7 +99,7 @@ TextureImporter:
     outline: []
     physicsShape: []
     bones: []
-    spriteID: 
+    spriteID: 5e97eb03825dee720800000000000000
     internalID: 0
     vertices: []
     indices: 

--- a/Assets/Designer/UI/InGame/Text_EmptyChest.png.meta
+++ b/Assets/Designer/UI/InGame/Text_EmptyChest.png.meta
@@ -6,7 +6,7 @@ TextureImporter:
   serializedVersion: 13
   mipmaps:
     mipMapMode: 0
-    enableMipMap: 1
+    enableMipMap: 0
     sRGBTexture: 1
     linearTexture: 0
     fadeOut: 0
@@ -37,13 +37,13 @@ TextureImporter:
     filterMode: 1
     aniso: 1
     mipBias: 0
-    wrapU: 0
-    wrapV: 0
+    wrapU: 1
+    wrapV: 1
     wrapW: 0
-  nPOTScale: 1
+  nPOTScale: 0
   lightmap: 0
   compressionQuality: 50
-  spriteMode: 0
+  spriteMode: 1
   spriteExtrude: 1
   spriteMeshType: 1
   alignment: 0
@@ -52,9 +52,9 @@ TextureImporter:
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
-  alphaIsTransparency: 0
+  alphaIsTransparency: 1
   spriteTessellationDetail: -1
-  textureType: 0
+  textureType: 8
   textureShape: 1
   singleChannelComponent: 0
   flipbookRows: 1
@@ -99,7 +99,7 @@ TextureImporter:
     outline: []
     physicsShape: []
     bones: []
-    spriteID: 
+    spriteID: 5e97eb03825dee720800000000000000
     internalID: 0
     vertices: []
     indices: 

--- a/Assets/Designer/UI/InGame/Text_IronBall.png.meta
+++ b/Assets/Designer/UI/InGame/Text_IronBall.png.meta
@@ -6,7 +6,7 @@ TextureImporter:
   serializedVersion: 13
   mipmaps:
     mipMapMode: 0
-    enableMipMap: 1
+    enableMipMap: 0
     sRGBTexture: 1
     linearTexture: 0
     fadeOut: 0
@@ -37,13 +37,13 @@ TextureImporter:
     filterMode: 1
     aniso: 1
     mipBias: 0
-    wrapU: 0
-    wrapV: 0
+    wrapU: 1
+    wrapV: 1
     wrapW: 0
-  nPOTScale: 1
+  nPOTScale: 0
   lightmap: 0
   compressionQuality: 50
-  spriteMode: 0
+  spriteMode: 1
   spriteExtrude: 1
   spriteMeshType: 1
   alignment: 0
@@ -52,9 +52,9 @@ TextureImporter:
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
-  alphaIsTransparency: 0
+  alphaIsTransparency: 1
   spriteTessellationDetail: -1
-  textureType: 0
+  textureType: 8
   textureShape: 1
   singleChannelComponent: 0
   flipbookRows: 1
@@ -99,7 +99,7 @@ TextureImporter:
     outline: []
     physicsShape: []
     bones: []
-    spriteID: 
+    spriteID: 5e97eb03825dee720800000000000000
     internalID: 0
     vertices: []
     indices: 

--- a/Assets/Designer/UI/InGame/Text_Pot.png.meta
+++ b/Assets/Designer/UI/InGame/Text_Pot.png.meta
@@ -6,7 +6,7 @@ TextureImporter:
   serializedVersion: 13
   mipmaps:
     mipMapMode: 0
-    enableMipMap: 1
+    enableMipMap: 0
     sRGBTexture: 1
     linearTexture: 0
     fadeOut: 0
@@ -37,13 +37,13 @@ TextureImporter:
     filterMode: 1
     aniso: 1
     mipBias: 0
-    wrapU: 0
-    wrapV: 0
+    wrapU: 1
+    wrapV: 1
     wrapW: 0
-  nPOTScale: 1
+  nPOTScale: 0
   lightmap: 0
   compressionQuality: 50
-  spriteMode: 0
+  spriteMode: 1
   spriteExtrude: 1
   spriteMeshType: 1
   alignment: 0
@@ -52,9 +52,9 @@ TextureImporter:
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
-  alphaIsTransparency: 0
+  alphaIsTransparency: 1
   spriteTessellationDetail: -1
-  textureType: 0
+  textureType: 8
   textureShape: 1
   singleChannelComponent: 0
   flipbookRows: 1
@@ -99,7 +99,7 @@ TextureImporter:
     outline: []
     physicsShape: []
     bones: []
-    spriteID: 
+    spriteID: 5e97eb03825dee720800000000000000
     internalID: 0
     vertices: []
     indices: 

--- a/Assets/Programmer/Prefabs/Gimmick/EmptyChest.prefab
+++ b/Assets/Programmer/Prefabs/Gimmick/EmptyChest.prefab
@@ -683,7 +683,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   gimmickImage: {fileID: 21300000, guid: 32ae138774dc419408dce89e5094adb4, type: 3}
-  gimmickTextImage: {fileID: 0}
+  gimmickTextImage: {fileID: 21300000, guid: b81f09c1a185e814c86c1410c9e817db, type: 3}
   gimmickSize: {x: 1, y: 1}
   gimmickScale: 100
   hitCheckerPrefab: {fileID: 5250139902968933795, guid: 20e32c23a30b34c45916d0dcbd7a0e58,

--- a/Assets/Programmer/Prefabs/Gimmick/Nyaki.prefab
+++ b/Assets/Programmer/Prefabs/Gimmick/Nyaki.prefab
@@ -67,6 +67,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   gimmickImage: {fileID: 21300000, guid: 96b8805ce28379a4584a2c2d2cf1a47d, type: 3}
+  gimmickTextImage: {fileID: 0}
   gimmickSize: {x: 1, y: 1}
   gimmickScale: 100
   hitCheckerPrefab: {fileID: 5250139902968933795, guid: 20e32c23a30b34c45916d0dcbd7a0e58,

--- a/Assets/Programmer/Prefabs/Gimmick/Pot.prefab
+++ b/Assets/Programmer/Prefabs/Gimmick/Pot.prefab
@@ -218,7 +218,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   gimmickImage: {fileID: 21300000, guid: ef0a22a2a0e100b40ab966865b36c4d0, type: 3}
-  gimmickTextImage: {fileID: 0}
+  gimmickTextImage: {fileID: 21300000, guid: e91321f727fb13d45a3102fba42e3ac2, type: 3}
   gimmickSize: {x: 1, y: 1}
   gimmickScale: 50
   hitCheckerPrefab: {fileID: 5250139902968933795, guid: 20e32c23a30b34c45916d0dcbd7a0e58,

--- a/Assets/Programmer/Prefabs/Gimmick/Rock.prefab
+++ b/Assets/Programmer/Prefabs/Gimmick/Rock.prefab
@@ -120,7 +120,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   gimmickImage: {fileID: 21300000, guid: 02fae2d52b94dcb42b44f7aefecb228d, type: 3}
-  gimmickTextImage: {fileID: 0}
+  gimmickTextImage: {fileID: 21300000, guid: 41a291d905d9ea741a6ecb21f958fffa, type: 3}
   gimmickSize: {x: 2, y: 2}
   gimmickScale: 100
   hitCheckerPrefab: {fileID: 5250139902968933795, guid: 20e32c23a30b34c45916d0dcbd7a0e58,

--- a/Assets/Programmer/Prefabs/UI/GameUI.prefab
+++ b/Assets/Programmer/Prefabs/UI/GameUI.prefab
@@ -1,5 +1,80 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &342077431573440951
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 595604678826530236}
+  - component: {fileID: 4803506875914904766}
+  - component: {fileID: 2268634917309939926}
+  m_Layer: 5
+  m_Name: Image
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &595604678826530236
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 342077431573440951}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 2, y: 0.5, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 640301655769134538}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 2, y: -87}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4803506875914904766
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 342077431573440951}
+  m_CullTransparentMesh: 1
+--- !u!114 &2268634917309939926
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 342077431573440951}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &453680083376022479
 GameObject:
   m_ObjectHideFlags: 0
@@ -632,6 +707,7 @@ MonoBehaviour:
   Center: {fileID: 7897216261148710544}
   Left: {fileID: 2391131555352738966}
   Right: {fileID: 6644006175381210485}
+  TextImage: {fileID: 342077431573440951}
   countText: {fileID: 2059519730298602789}
   animationSpeed: 5
   sideAlpha: 0.45
@@ -872,7 +948,8 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 595604678826530236}
   m_Father: {fileID: 9007557476102195993}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}

--- a/Assets/Programmer/Scripts/UI/SelectUI.cs
+++ b/Assets/Programmer/Scripts/UI/SelectUI.cs
@@ -9,6 +9,7 @@ public class GimmickSelectUI : MonoBehaviour
     [SerializeField] private GameObject Center;
     [SerializeField] private GameObject Left;
     [SerializeField] private GameObject Right;
+    [SerializeField] private GameObject TextImage;
 
     [Header("所持数テキスト（TMP_Text）")]
     [SerializeField] private TMP_Text countText;
@@ -38,7 +39,7 @@ public class GimmickSelectUI : MonoBehaviour
     private CS_PlayerAction playerAction;
     private GimmickManager gimmickManager;
 
-    private Image centerImg, leftImg, rightImg;
+    private Image centerImg, leftImg, rightImg,TextImg;
     private RectTransform centerRT, leftRT, rightRT;
 
     private Vector2 centerAnchor, leftAnchor, rightAnchor;
@@ -57,6 +58,7 @@ public class GimmickSelectUI : MonoBehaviour
         centerImg = Center.GetComponent<Image>();
         leftImg = Left.GetComponent<Image>();
         rightImg = Right.GetComponent<Image>();
+        TextImg = TextImage.GetComponent<Image>();
 
         centerRT = Center.GetComponent<RectTransform>();
         leftRT = Left.GetComponent<RectTransform>();
@@ -257,9 +259,13 @@ public class GimmickSelectUI : MonoBehaviour
         int leftIdx = (idx - 1 + count) % count;
         int rightIdx = (idx + 1) % count;
 
+        Sprite TextImage = playerAction.gimmickKind[idx]?.GetComponent<GimmickBase>()?.gimmickTextImage;
+
+
         SetImage(centerImg, GetSprite(idx), 1f);
         SetImage(leftImg, GetSprite(leftIdx), sideAlpha);
         SetImage(rightImg, GetSprite(rightIdx), sideAlpha);
+        SetImage(TextImg, TextImage, 1f);
 
         RefreshCoolTimeCache(idx);
     }


### PR DESCRIPTION
This pull request updates the configuration and usage of several UI textures and prefabs to improve sprite rendering and support for displaying associated text images in the game's UI. The main changes involve adjusting Unity texture import settings for multiple UI assets, adding and wiring up a new text image field for gimmick selection, and updating prefabs to use the new images.

**Texture Import Settings Updates:**

* Disabled mipmaps and enabled wrapping on the `Number.png`, `Text_EmptyChest.png`, `Text_IronBall.png`, and `Text_Pot.png` textures, set them to sprite mode, enabled alpha transparency, and assigned new sprite IDs. These changes ensure the textures are optimized for UI sprite use and support transparency correctly. [[1]](diffhunk://#diff-560079db9f44d9345e44b50700c82ec3263a1ce6c6654a9572bb2aad1d8d81c5L9-R9) [[2]](diffhunk://#diff-560079db9f44d9345e44b50700c82ec3263a1ce6c6654a9572bb2aad1d8d81c5L40-R46) [[3]](diffhunk://#diff-560079db9f44d9345e44b50700c82ec3263a1ce6c6654a9572bb2aad1d8d81c5L55-R57) [[4]](diffhunk://#diff-560079db9f44d9345e44b50700c82ec3263a1ce6c6654a9572bb2aad1d8d81c5L102-R102) [[5]](diffhunk://#diff-ae311546e928590fcc492e66c7239a58697469f0561b15fb628027ba84cf1643L9-R9) [[6]](diffhunk://#diff-ae311546e928590fcc492e66c7239a58697469f0561b15fb628027ba84cf1643L40-R46) [[7]](diffhunk://#diff-ae311546e928590fcc492e66c7239a58697469f0561b15fb628027ba84cf1643L55-R57) [[8]](diffhunk://#diff-ae311546e928590fcc492e66c7239a58697469f0561b15fb628027ba84cf1643L102-R102) [[9]](diffhunk://#diff-c36d29ec13f48cd1d3420b0b3b711afe550c238b054d44abf5a60e5b824c98a4L9-R9) [[10]](diffhunk://#diff-c36d29ec13f48cd1d3420b0b3b711afe550c238b054d44abf5a60e5b824c98a4L40-R46) [[11]](diffhunk://#diff-c36d29ec13f48cd1d3420b0b3b711afe550c238b054d44abf5a60e5b824c98a4L55-R57) [[12]](diffhunk://#diff-c36d29ec13f48cd1d3420b0b3b711afe550c238b054d44abf5a60e5b824c98a4L102-R102) [[13]](diffhunk://#diff-f56749579b4b0baac25dc2272a40a6f98edc15ef45a77533e58eab579fb2d953L9-R9) [[14]](diffhunk://#diff-f56749579b4b0baac25dc2272a40a6f98edc15ef45a77533e58eab579fb2d953L40-R46) [[15]](diffhunk://#diff-f56749579b4b0baac25dc2272a40a6f98edc15ef45a77533e58eab579fb2d953L55-R57) [[16]](diffhunk://#diff-f56749579b4b0baac25dc2272a40a6f98edc15ef45a77533e58eab579fb2d953L102-R102)

**Prefab Updates for Gimmick Text Images:**

* Updated the `EmptyChest`, `Pot`, and `Rock` gimmick prefabs to assign the appropriate `gimmickTextImage` sprite, and initialized the field for `Nyaki` (set to none). This allows each gimmick to display its corresponding text image in the UI. [[1]](diffhunk://#diff-1f9450e3f5e66a6c3a4c5542239cb1f1548f9e8c7f4186eccf673a3a67c12034L686-R686) [[2]](diffhunk://#diff-3f6221cc9b9fb8cdea0c100563a775161c129db2e50a8c8a82a4b2c63cd0eb17L221-R221) [[3]](diffhunk://#diff-90a167ccf98ca4246d6cbbefce25275828518f9d4465c9d96d0f468e0d4017faL123-R123) [[4]](diffhunk://#diff-a1da369542e8b68b2e1f27e7c785c7cc4c52f32dcf08826f14731e4dd6c68d3eR70)

**Game UI Prefab and Script Enhancements:**

* Added a new `Image` GameObject to the `GameUI` prefab for displaying the gimmick's text image, set its transform, and linked it in the UI script. [[1]](diffhunk://#diff-b0c8153dc0e3eef79ff1c76acf8406862b3dc17d26e842666778b4b0119082b8R3-R77) [[2]](diffhunk://#diff-b0c8153dc0e3eef79ff1c76acf8406862b3dc17d26e842666778b4b0119082b8L875-R952) [[3]](diffhunk://#diff-b0c8153dc0e3eef79ff1c76acf8406862b3dc17d26e842666778b4b0119082b8R710)
* Updated `GimmickSelectUI` in `SelectUI.cs` to serialize and reference the new `TextImage` GameObject, cache its `Image` component, and update it with the current gimmick's text image in `RefreshImages()`. [[1]](diffhunk://#diff-22ff6fd2674a50082c57b53d00f7ecf39152f6ef7e76cb324dd414dffef9b601R12) [[2]](diffhunk://#diff-22ff6fd2674a50082c57b53d00f7ecf39152f6ef7e76cb324dd414dffef9b601L41-R42) [[3]](diffhunk://#diff-22ff6fd2674a50082c57b53d00f7ecf39152f6ef7e76cb324dd414dffef9b601R61) [[4]](diffhunk://#diff-22ff6fd2674a50082c57b53d00f7ecf39152f6ef7e76cb324dd414dffef9b601R262-R268)