### PR TITLE
fix: ネコタンマテリアルのシェーダー参照を更新

### DIFF
--- a/Assets/Programmer/Materials/Character/Cat/MT_Cat_1.mat
+++ b/Assets/Programmer/Materials/Character/Cat/MT_Cat_1.mat
@@ -8,9 +8,9 @@ Material:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: MT_Cat_1
-  m_Shader: {fileID: -6465566751694194690, guid: 3fbabf8991b020748bbe1130aa7b6184,
+  m_Shader: {fileID: -6465566751694194690, guid: 4f43b46da54065a42a2f16b0a5c56ffb,
     type: 3}
-  m_Parent: {fileID: 2100000, guid: b5dc78e9af9824e45bec50a6591a0c70, type: 2}
+  m_Parent: {fileID: 2100000, guid: 6cc41fb1c85ea0b469ad432acdfe9c14, type: 2}
   m_ModifiedSerializedProperties: 2
   m_ValidKeywords: []
   m_InvalidKeywords: []

--- a/Assets/Programmer/Materials/Character/Cat/MT_Cat_2.mat
+++ b/Assets/Programmer/Materials/Character/Cat/MT_Cat_2.mat
@@ -8,9 +8,9 @@ Material:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: MT_Cat_2
-  m_Shader: {fileID: -6465566751694194690, guid: 3fbabf8991b020748bbe1130aa7b6184,
+  m_Shader: {fileID: -6465566751694194690, guid: 4f43b46da54065a42a2f16b0a5c56ffb,
     type: 3}
-  m_Parent: {fileID: 2100000, guid: b5dc78e9af9824e45bec50a6591a0c70, type: 2}
+  m_Parent: {fileID: 2100000, guid: 6cc41fb1c85ea0b469ad432acdfe9c14, type: 2}
   m_ModifiedSerializedProperties: 2
   m_ValidKeywords: []
   m_InvalidKeywords: []

--- a/Assets/Programmer/Materials/Character/Cat/MT_Cat_3.mat
+++ b/Assets/Programmer/Materials/Character/Cat/MT_Cat_3.mat
@@ -8,9 +8,9 @@ Material:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: MT_Cat_3
-  m_Shader: {fileID: -6465566751694194690, guid: 3fbabf8991b020748bbe1130aa7b6184,
+  m_Shader: {fileID: -6465566751694194690, guid: 4f43b46da54065a42a2f16b0a5c56ffb,
     type: 3}
-  m_Parent: {fileID: 2100000, guid: b5dc78e9af9824e45bec50a6591a0c70, type: 2}
+  m_Parent: {fileID: 2100000, guid: 6cc41fb1c85ea0b469ad432acdfe9c14, type: 2}
   m_ModifiedSerializedProperties: 2
   m_ValidKeywords: []
   m_InvalidKeywords: []

--- a/Assets/Programmer/Materials/Character/Cat/MT_Cat_4.mat
+++ b/Assets/Programmer/Materials/Character/Cat/MT_Cat_4.mat
@@ -8,9 +8,9 @@ Material:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: MT_Cat_4
-  m_Shader: {fileID: -6465566751694194690, guid: 3fbabf8991b020748bbe1130aa7b6184,
+  m_Shader: {fileID: -6465566751694194690, guid: 4f43b46da54065a42a2f16b0a5c56ffb,
     type: 3}
-  m_Parent: {fileID: 2100000, guid: b5dc78e9af9824e45bec50a6591a0c70, type: 2}
+  m_Parent: {fileID: 2100000, guid: 6cc41fb1c85ea0b469ad432acdfe9c14, type: 2}
   m_ModifiedSerializedProperties: 2
   m_ValidKeywords: []
   m_InvalidKeywords: []
@@ -34,6 +34,7 @@ Material:
         m_Offset: {x: 0, y: 0}
     m_Ints: []
     m_Floats:
+    - _Alpha: 1
     - _UseNormalMap: 0
     m_Colors: []
   m_BuildTextureStacks: []


### PR DESCRIPTION
SkinnedMeshRendererへの変更に伴い、_Alphaプロパティを持つシェーダーへ参照を修正