### PR TITLE
fix: Optionのリファクタ及び、Build時のバグ修正

### DIFF
--- a/Assets/Programmer/Scripts/UI/Option.cs
+++ b/Assets/Programmer/Scripts/UI/Option.cs
@@ -10,6 +10,10 @@ using UnityEngine.SceneManagement;
 
 public class Option : MonoBehaviour
 {
+    private const string CanvasesObjectName = "Canvases";
+    private const string GameUICanvasName = "GameUICavas";
+    private const string OptionCanvasObjectName = "OptionCanvas";
+
     private static Option _instance;
 
     [SerializeField] private float _bgmVolume = 100.0f; // BGMの音量
@@ -26,13 +30,7 @@ public class Option : MonoBehaviour
     /// <summary>
     /// インスタンスを取得するプロパティ
     /// </summary>
-    public static Option Instance
-    {
-        get
-        {
-            return _instance;
-        }
-    }
+    public static Option Instance => _instance;
 
     /// <summary>
     /// インスタンスを破棄
@@ -66,19 +64,37 @@ public class Option : MonoBehaviour
         // Option入力のトリガー登録
         _input.Player.Option.performed += OnOption;
 
-        GameObject canvase = GameObject.Find("Canvases");
-        if(canvase == null)
+        GameUI = FindGameUI();
+    }
+
+    private void OnDestroy()
+    {
+        if (_input != null)
         {
-            Debug.Log("Canvasesオブジェクトが見つかりません。");
-            return;
+            _input.Player.Option.performed -= OnOption;
         }
-        Transform gameUITransform = canvase.transform.Find("GameUICavas");
+    }
+
+    /// <summary>
+    /// "Canvases/GameUICavas" を探して取得する
+    /// </summary>
+    private GameObject FindGameUI()
+    {
+        GameObject canvases = GameObject.Find(CanvasesObjectName);
+        if (canvases == null)
+        {
+            Debug.Log($"{CanvasesObjectName}オブジェクトが見つかりません。");
+            return null;
+        }
+
+        Transform gameUITransform = canvases.transform.Find(GameUICanvasName);
         if (gameUITransform == null)
         {
-            Debug.Log("GameUICavasオブジェクトが見つかりません。");
-            return;
+            Debug.Log($"{GameUICanvasName}オブジェクトが見つかりません。");
+            return null;
         }
-        GameUI = gameUITransform.gameObject;
+
+        return gameUITransform.gameObject;
     }
 
     /// <summary>
@@ -87,20 +103,20 @@ public class Option : MonoBehaviour
     private void OnOption(InputAction.CallbackContext ctx)
     {
         // タイトルシーンではオプションUIを開かない
-        if (SceneManager.GetActiveScene().name.ToString() == "TitleScene") return;
+        if (SceneManager.GetActiveScene().name == "TitleScene") return;
+
         if (!_isOptionUIActive)
         {
             OpenOptionUI();
         }
         else
         {
-            if(_prevOption== null)
+            if (_prevOption == null)
             {
                 Debug.LogError("OptionUIが存在しません。");
                 return;
             }
-            OptionSys optionSys = _prevOption.GetComponent<OptionSys>();
-            if (optionSys == null)
+            if (_prevOption.GetComponent<OptionSys>() == null)
             {
                 Debug.LogError("OptionUIにOptionSysコンポーネントがアタッチされていません。");
                 return;
@@ -120,10 +136,10 @@ public class Option : MonoBehaviour
         if (_prevOption == null)
         {
             // Canvasを探してその子オブジェクトとしてOptionUIを生成
-            GameObject canvas = GameObject.Find("OptionCanvas");
+            GameObject canvas = GameObject.Find(OptionCanvasObjectName);
             if (canvas == null)
             {
-                Debug.LogError("OptionCanvasオブジェクトが見つかりません。");
+                Debug.LogError($"{OptionCanvasObjectName}オブジェクトが見つかりません。");
                 return;
             }
             _prevOption = Instantiate(OptionUI, Vector3.zero, Quaternion.identity, canvas.transform);
@@ -131,16 +147,9 @@ public class Option : MonoBehaviour
             rectTransform.anchoredPosition = Vector2.zero;
         }
 
-        if(GameUI == null)
+        if (GameUI == null)
         {
-            GameObject canvase = GameObject.Find("Canvases");
-            if(canvase == null)
-            {
-                Debug.Log("Canvasesオブジェクトが見つかりません。");
-                return;
-            }
-            Transform gameUITransform = canvase.transform.Find("GameUICavas");
-            GameUI = gameUITransform != null ? gameUITransform.gameObject : null;
+            GameUI = FindGameUI();
         }
         if (GameUI != null)
         {
@@ -158,16 +167,7 @@ public class Option : MonoBehaviour
     {
         if (GameUI == null)
         {
-            GameObject canvase = GameObject.Find("Canvases");
-            if (canvase == null)
-            {
-                Debug.Log("Canvasesオブジェクトが見つかりません。");
-            }
-            else
-            {
-                Transform gameUITransform = canvase.transform.Find("GameUICavas");
-                GameUI = gameUITransform != null ? gameUITransform.gameObject : null;
-            }
+            GameUI = FindGameUI();
         }
         if (GameUI != null)
         {
@@ -181,8 +181,6 @@ public class Option : MonoBehaviour
         _isOptionUIActive = false;
         Time.timeScale = 1f;
     }
-
-    
 
     /// <summary>
     /// BGMの音量を設定

--- a/Assets/Programmer/Scripts/UI/OptionSys.cs
+++ b/Assets/Programmer/Scripts/UI/OptionSys.cs
@@ -3,11 +3,12 @@ using UnityEngine;
 using UnityEngine.InputSystem;
 using UnityEngine.SceneManagement;
 using UnityEngine.UI;
-using static HoudiniEngineUnity.HEU_InputNode;
 
 public class OptionSys : MonoBehaviour
 {
-    [SerializeField] string optionManagerStr = "";
+    private const int BackToGameIndex = 2;
+    private const int BackToTitleIndex = 3;
+
     [SerializeField] GameObject[] optionUI;
     [SerializeField] Sprite[] detailSprite;
     [SerializeField] GameObject detail;
@@ -17,18 +18,15 @@ public class OptionSys : MonoBehaviour
     [SerializeField] Image seSoundBar;
     [SerializeField] Sprite closeImg;
 
-
     struct SelectGameObject
     {
-        public GameObject Object_True;
-        public GameObject Object_False;
+        public GameObject TrueObject;
+        public GameObject FalseObject;
     }
 
     List<SelectGameObject> selectGameObjects = new List<SelectGameObject>();
     [SerializeField] private int selected = 0;
     CustomInputAction inputAction;
-    GameObject optionMangerObj;
-    Option option;
 
     float seSoundValue = 0;
     float bgmSoundValue = 0;
@@ -37,79 +35,54 @@ public class OptionSys : MonoBehaviour
 
     private void Awake()
     {
-        string sceneName = SceneManager.GetActiveScene().name.ToString();
-        if (sceneName == "MainScene")
-        {
-            isInGame = true;
-        }
+        isInGame = SceneManager.GetActiveScene().name == "MainScene";
 
         if (!isInGame && optionUI.Length >= 4)
         {
-            optionUI[2].SetActive(false);
-            Transform textTransform = optionUI[3].transform.Find("Text");
+            optionUI[BackToGameIndex].SetActive(false);
+            Transform textTransform = optionUI[BackToTitleIndex].transform.Find("Text");
             if (textTransform != null)
             {
-                Image textImge = textTransform.GetComponent<Image>();
-                if (textImge != null)
+                Image textImage = textTransform.GetComponent<Image>();
+                if (textImage != null)
                 {
-                    textImge.sprite = closeImg;
+                    textImage.sprite = closeImg;
                 }
             }
         }
 
-        for (int i = 0 ; i < optionUI.Length ; i++)
+        for (int i = 0; i < optionUI.Length; i++)
         {
-            if(!isInGame && i == 2)
+            if (!isInGame && i == BackToGameIndex)
             {
                 continue;
             }
-            SelectGameObject TempSelectObject = new SelectGameObject();
-            TempSelectObject.Object_True = optionUI[i].transform.Find("Select_true").gameObject;
-            TempSelectObject.Object_False = optionUI[i].transform.Find("Select_false").gameObject;
-            selectGameObjects.Add(TempSelectObject);
+
+            selectGameObjects.Add(new SelectGameObject
+            {
+                TrueObject = optionUI[i].transform.Find("Select_true").gameObject,
+                FalseObject = optionUI[i].transform.Find("Select_false").gameObject
+            });
         }
+
         inputAction = CS_CustomInputActionManager.instance.customInputAction;
         inputAction.Option.Up.started += Up;
         inputAction.Option.Down.started += Down;
         inputAction.Option.Decision.started += Enter;
 
-        optionMangerObj = GameObject.Find(optionManagerStr);
-        if (optionMangerObj == null)
+        // OptionSysはOption.OpenOptionUI()自身がInstantiateして生成するため、
+        // この時点でOption.Instanceは必ず存在している
+        if (Option.Instance == null)
         {
-            Debug.Log("OptionManagerが見つかりません");
-            return;
-        }
-        option = optionMangerObj.GetComponent<Option>();
-        if (option == null)
-        {
-            Debug.Log("Optionコンポーネントが見つかりません");
+            Debug.LogError("Optionが見つかりません。");
             return;
         }
 
-        seSoundValue = option.GetSEVolume();
-        bgmSoundValue = option.GetBGMVolume();
+        seSoundValue = Option.Instance.GetSEVolume();
+        bgmSoundValue = Option.Instance.GetBGMVolume();
 
-        Vector3 bgmSoundBarPos = bgmSoundBar.transform.position;
-        Vector2 bgmSoundBarSize = bgmSoundBar.rectTransform.sizeDelta;
-
-        float barLeftX = bgmSoundBarPos.x - (bgmSoundBarSize.x / 2.0f);
-        float tempX = barLeftX + (bgmSoundBarSize.x * bgmSoundBar.fillAmount);
-
-        Vector3 cursor = bgmCursor.transform.position;
-        cursor.x = tempX;
-        bgmCursor.transform.position = cursor;
-
-
-
-        Vector3 seSoundBarPos = seSoundBar.transform.position;
-        Vector2 seSoundBarSize = seSoundBar.rectTransform.sizeDelta;
-
-        float barLeftX2 = seSoundBarPos.x - (seSoundBarSize.x / 2.0f);
-        float tempX2 = barLeftX2 + (seSoundBarSize.x * seSoundBar.fillAmount);
-
-        Vector3 cursor2 = seCursor.transform.position;
-        cursor2.x = tempX2;
-        seCursor.transform.position = cursor2;
+        UpdateSoundCursor(bgmSoundBar, bgmCursor);
+        UpdateSoundCursor(seSoundBar, seCursor);
     }
 
     private void OnDestroy()
@@ -134,7 +107,7 @@ public class OptionSys : MonoBehaviour
         {
             selected = selectGameObjects.Count - 1;
         }
-        else if(selected >= selectGameObjects.Count)
+        else if (selected >= selectGameObjects.Count)
         {
             selected = 0;
         }
@@ -142,46 +115,36 @@ public class OptionSys : MonoBehaviour
         bgmSoundBar.fillAmount = bgmSoundValue / 100f;
         seSoundBar.fillAmount = seSoundValue / 100f;
 
-        Image image = detail.GetComponent<Image>();
         if (selected >= 0 && selected < detailSprite.Length)
         {
-            image.sprite = detailSprite[selected];
+            detail.GetComponent<Image>().sprite = detailSprite[selected];
         }
 
-        // Cursor計算
-        Vector3 bgmSoundBarPos = bgmSoundBar.transform.position;
-        Vector2 bgmSoundBarSize = bgmSoundBar.rectTransform.sizeDelta;
+        UpdateSoundCursor(bgmSoundBar, bgmCursor);
+        UpdateSoundCursor(seSoundBar, seCursor);
 
-        float barLeftX = bgmSoundBarPos.x - (bgmSoundBarSize.x / 2.0f);
-        float tempX = barLeftX + (bgmSoundBarSize.x * bgmSoundBar.fillAmount);
-
-        Vector3 cursor = bgmCursor.transform.position;
-        cursor.x = tempX;
-        bgmCursor.transform.position = cursor;
-
-        Vector3 seSoundBarPos = seSoundBar.transform.position;
-        Vector2 seSoundBarSize = seSoundBar.rectTransform.sizeDelta;
-
-        float barLeftX2 = seSoundBarPos.x - (seSoundBarSize.x / 2.0f);
-        float tempX2 = barLeftX2 + (seSoundBarSize.x * seSoundBar.fillAmount);
-
-        Vector3 cursor2 = seCursor.transform.position;
-        cursor2.x = tempX2;
-        seCursor.transform.position = cursor2;
-
-        for (int i = 0 ; i < selectGameObjects.Count ; i++)
+        for (int i = 0; i < selectGameObjects.Count; i++)
         {
-            if (i == selected)
-            {
-                selectGameObjects[i].Object_True.SetActive(true);
-                selectGameObjects[i].Object_False.SetActive(false);
-            }
-            else
-            {
-                selectGameObjects[i].Object_True.SetActive(false);
-                selectGameObjects[i].Object_False.SetActive(true);
-            }
+            bool isSelected = i == selected;
+            selectGameObjects[i].TrueObject.SetActive(isSelected);
+            selectGameObjects[i].FalseObject.SetActive(!isSelected);
         }
+    }
+
+    /// <summary>
+    /// 音量バーの見た目の値に合わせてカーソル位置を更新
+    /// </summary>
+    private void UpdateSoundCursor(Image soundBar, GameObject cursor)
+    {
+        Vector3 barPos = soundBar.transform.position;
+        Vector2 barSize = soundBar.rectTransform.sizeDelta;
+
+        float barLeftX = barPos.x - (barSize.x / 2.0f);
+        float cursorX = barLeftX + (barSize.x * soundBar.fillAmount);
+
+        Vector3 cursorPos = cursor.transform.position;
+        cursorPos.x = cursorX;
+        cursor.transform.position = cursorPos;
     }
 
     private void Up(InputAction.CallbackContext context)
@@ -193,146 +156,73 @@ public class OptionSys : MonoBehaviour
     {
         selected++;
     }
+
     private void Enter(InputAction.CallbackContext context)
     {
-        string DebugStr = "Enterが押されました。選択中の項目は" + selected + "です。";
-        Debug.Log(DebugStr);
-        switch (selected)
+        if (selected != BackToGameIndex && selected != BackToTitleIndex)
         {
-            case 0:
-                break;
-            case 1:
-                break;
-            case 2:
+            return;
+        }
+
+        if (Option.Instance == null)
+        {
+            Debug.LogError("Optionが見つかりません。");
+            return;
+        }
+
+        Option.Instance.CloseOptionUI();
+
+        if (selected == BackToTitleIndex)
+        {
+            CS_SceneTransition sceneTransition = FindFirstObjectByType<CS_SceneTransition>();
+            if (sceneTransition != null)
             {
-                if (option == null)
-                {
-                    if (optionMangerObj == null)
-                    {
-                        optionMangerObj = GameObject.Find(optionManagerStr);
-                        if (optionMangerObj == null)
-                        {
-                            Debug.Log("OptionManagerが見つかりません");
-                            return;
-                        }
-                    }
-                    option = optionMangerObj.GetComponent<Option>();
-                    if (option == null)
-                    {
-                        Debug.Log("Optionコンポーネントが見つかりません");
-                        return;
-                    }
-                }
-                option.CloseOptionUI();
+                sceneTransition.StartSceneTransition("TitleScene");
             }
-                break;
-            case 3:
-                {
-                    if (option == null)
-                    {
-                        if (optionMangerObj == null)
-                        {
-                            optionMangerObj = GameObject.Find(optionManagerStr);
-                            if (optionMangerObj == null)
-                            {
-                                Debug.Log("OptionManagerが見つかりません");
-                                return;
-                            }
-                        }
-                        option = optionMangerObj.GetComponent<Option>();
-                        if (option == null)
-                        {
-                            Debug.Log("Optionコンポーネントが見つかりません");
-                            return;
-                        }
-                    }
-                    option.CloseOptionUI();
-                    CS_SceneTransition sceneTransition = FindFirstObjectByType<CS_SceneTransition>();
-                    if (sceneTransition != null)
-                    {
-                        sceneTransition.StartSceneTransition("TitleScene");
-                    }
-                    else
-                    {
-                        Debug.LogError("CS_SceneTransitionが見つかりません");
-                    }
-                    break;
-                }
+            else
+            {
+                Debug.LogError("CS_SceneTransitionが見つかりません");
+            }
         }
     }
 
     private void Left()
     {
-        if (option == null)
+        if (Option.Instance == null)
         {
-            if (optionMangerObj == null)
-            {
-                optionMangerObj = GameObject.Find(optionManagerStr);
-                if (optionMangerObj == null)
-                {
-                    Debug.Log("OptionManagerが見つかりません");
-                    return;
-                }
-            }
-            option = optionMangerObj.GetComponent<Option>();
-            if (option == null)
-            {
-                Debug.Log("Optionコンポーネントが見つかりません");
-                return;
-            }
+            Debug.LogError("Optionが見つかりません。");
+            return;
         }
-
 
         if (selected == 0)
         {
-            bgmSoundValue = option.GetBGMVolume();
-            bgmSoundValue -= 0.1f;
-            if (bgmSoundValue < 0) bgmSoundValue = 0;
-            option.SetBGMVolume(bgmSoundValue);
+            bgmSoundValue = Mathf.Max(0f, Option.Instance.GetBGMVolume() - 0.1f);
+            Option.Instance.SetBGMVolume(bgmSoundValue);
         }
         else if (selected == 1)
         {
-            seSoundValue = option.GetSEVolume();
-            seSoundValue -= 0.1f;
-            if (seSoundValue < 0) seSoundValue = 0;
-            option.SetSEVolume(seSoundValue);
+            seSoundValue = Mathf.Max(0f, Option.Instance.GetSEVolume() - 0.1f);
+            Option.Instance.SetSEVolume(seSoundValue);
         }
     }
 
     private void Right()
     {
-        if (option == null)
+        if (Option.Instance == null)
         {
-            if (optionMangerObj == null)
-            {
-                optionMangerObj = GameObject.Find(optionManagerStr);
-                if (optionMangerObj == null)
-                {
-                    Debug.Log("OptionManagerが見つかりません");
-                    return;
-                }
-            }
-            option = optionMangerObj.GetComponent<Option>();
-            if (option == null)
-            {
-                Debug.Log("Optionコンポーネントが見つかりません");
-                return;
-            }
+            Debug.LogError("Optionが見つかりません。");
+            return;
         }
 
         if (selected == 0)
         {
-            bgmSoundValue = option.GetBGMVolume();
-            bgmSoundValue += 0.1f;
-            if (bgmSoundValue > 100) bgmSoundValue = 100;
-            option.SetBGMVolume(bgmSoundValue);
+            bgmSoundValue = Mathf.Min(100f, Option.Instance.GetBGMVolume() + 0.1f);
+            Option.Instance.SetBGMVolume(bgmSoundValue);
         }
         else if (selected == 1)
         {
-            seSoundValue = option.GetSEVolume();
-            seSoundValue += 0.1f;
-            if (seSoundValue > 100) seSoundValue = 100;
-            option.SetSEVolume(seSoundValue);
+            seSoundValue = Mathf.Min(100f, Option.Instance.GetSEVolume() + 0.1f);
+            Option.Instance.SetSEVolume(seSoundValue);
         }
     }
 }


### PR DESCRIPTION
原因: OptionSys.csがOptionシングルトンを取得する際、Option.InstanceではなくGameObject.Find(optionManagerStr)という名前文字列検索を使っていたこと。

なぜビルドでだけ症状が出るか:

OptionはDontDestroyOnLoadのシングルトンで、GameOptionManagerという同名のプレハブがTitleScene・MainSceneなど複数シーンに重複配置されている。
シーン遷移時、後から読み込まれた側の複製はAwake()で「もうインスタンスがある」と気づきDestroy(this.gameObject)を呼ぶが、UnityのDestroy()は同フレーム内では即時に消えないため、一瞬だけ「本物」と「破棄待ちの偽物」の2つのGameOptionManagerが同時に存在する。
この一瞬にGameObject.Find("GameOptionManager")を呼ぶと、複数該当オブジェクトのうちどちらが返るかはUnity内部の探索順序に依存し、エディタとビルドで挙動が異なりうる(エディタではたまたま本物を拾い、ビルドでは破棄待ちの偽物を拾う、など)。
偽物を掴んでしまうと、「ゲームに戻る」選択時に呼ばれるCloseOptionUI()が本物ではなく偽物のOptionコンポーネントに対して実行される。偽物側は_prevOption(実際に表示中のOptionUIパネル)を持っていないため何も破棄されず、実際に画面を開いている本物のシングルトン側は_isOptionUIActiveがtrueのまま、UIパネルも残り続ける → Optionが閉じない。
対処: OptionSysはOption.OpenOptionUI()自身がInstantiateして生成する子オブジェクトなので、生成された時点でOption.Instanceは必ず本物を指している。名前検索を撤廃し、他のスクリプト群(CS_BackGroundPlaySE等)と同様にOption.Instanceを直接参照する形に統一したことで、この名前衝突・探索順序依存の問題自体を解消した。